### PR TITLE
MIINOR: Downgrade to Avro 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Version 0.1.1
 -------------
+* Downgrade to Avro 1.8.1 to avoid a [critical Avro bug](https://issues.apache.org/jira/browse/AVRO-2122)
 * Include LICENSE in repository and packaged connector
 * Updated Maven build process
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <confluent.version>5.1.0</confluent.version>
         <confluent.avro.generator.version>0.2.0</confluent.avro.generator.version>
         <junit.version>4.12</junit.version>
-        <avro.version>1.8.2</avro.version>
+        <avro.version>1.8.1</avro.version>
         <licenses.version>5.1.0</licenses.version>
     </properties>
 


### PR DESCRIPTION
Avro 1.8.2 contains a critical bug (https://issues.apache.org/jira/browse/AVRO-2122). Downgrading to 1.8.1 to reflect Confluent Platform 5.x and to avoid this potential problem.