### PR TITLE
Checkout latest version from Confluent Hub

### DIFF
--- a/Dockerfile-confluenthub
+++ b/Dockerfile-confluenthub
@@ -17,4 +17,4 @@ FROM confluentinc/cp-kafka-connect:5.0.0
 
 ENV CONNECT_PLUGIN_PATH="/usr/share/java,/usr/share/confluent-hub-components"
 
-RUN  confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.1
+RUN confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:latest


### PR DESCRIPTION
Avoid issue reported in https://github.com/confluentinc/cp-docker-images/pull/659

```bash
kafka-connect-datagen(VERSION_LATEST): confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.0

Running in a "--no-prompt" mode 

Implicit acceptance of the license below:  
The Apache License, Version 2.0 
https://www.apache.org/licenses/LICENSE-2.0 
Downloading component Kafka Connect Datagen 0.1.0, provided by Confluent, Inc. from Confluent Hub and installing into /Users/yeva/code/confluent_home/share/confluent-hub-components 
Implicit confirmation of the question: Do you want to uninstall existing version 0.1.0? 
Adding installation directory to plugin path in the following files: 
  /Users/yeva/code/confluent_home/etc/kafka/connect-distributed.properties 
  /Users/yeva/code/confluent_home/etc/kafka/connect-standalone.properties 
  /Users/yeva/code/confluent_home/etc/schema-registry/connect-avro-distributed.properties 
  /Users/yeva/code/confluent_home/etc/schema-registry/connect-avro-standalone.properties 
 
Completed 
kafka-connect-datagen(VERSION_LATEST): 
kafka-connect-datagen(VERSION_LATEST): confluent-hub install --no-prompt confluentinc/kafka-connect-datagen:0.1.1
Running in a "--no-prompt" mode 
Unable to find a component 
 
Error: Component not found, specify either valid name from Confluent Hub in format: <owner>/<name>:<version:latest> or path to a local file 
```