### PR TITLE
Include parameters in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ See all Kafka Connect [configuration parameters](https://docs.confluent.io/curre
 
 Parameter | Description | Default
 -|-|-
-kafka.topic | Topic to write to | 
-max.interval | Max interval between messages (ms) | 500
-iterations | Number of messages to send, or less than 1 for unlimited | -1
-schema.filename | Filename of schema to use
-schema.keyfield | Name of field to use as the message key
-quickstart | Name of [quickstart](https://github.com/confluentinc/kafka-connect-datagen/tree/master/src/main/resources) to use
+`kafka.topic` | Topic to write to | 
+`max.interval` | Max interval between messages (ms) | 500
+`iterations` | Number of messages to send, or less than 1 for unlimited | -1
+`schema.filename` | Filename of schema to use
+`schema.keyfield` | Name of field to use as the message key
+`quickstart` | Name of [quickstart](https://github.com/confluentinc/kafka-connect-datagen/tree/master/src/main/resources) to use
 
 ## Sample configurations
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ To define your own schema:
 ...
 ```
 
+_The custom schema can be used at runtime; it is not necessary to recompile the connector_.
+
 # Confusion about schemas and Avro
 
 To define the set of "rules" for the mock data, `kafka-connect-datagen` uses [Avro Random Generator](https://github.com/confluentinc/avro-random-generator).

--- a/README.md
+++ b/README.md
@@ -98,7 +98,14 @@ See all Kafka Connect [configuration parameters](https://docs.confluent.io/curre
 
 ## Connector-specific Parameters
 
-See `kafka-connect-datagen` [configuration parameters](https://github.com/confluentinc/kafka-connect-datagen/blob/master/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnectorConfig.java) and their defaults.
+Parameter | Description | Default
+-|-|-
+kafka.topic | Topic to write to | 
+max.interval | Max interval between messages (ms) | 500
+iterations | Number of messages to send, or less than 1 for unlimited | -1
+schema.filename | Filename of schema to use
+schema.keyfield | Name of field to use as the message key
+quickstart | Name of [quickstart](https://github.com/confluentinc/kafka-connect-datagen/tree/master/src/main/resources) to use
 
 ## Sample configurations
 


### PR DESCRIPTION
It's easier for end-users to have the config listed in the docs, plus not all users will be comfortable reading/guessing at what the Java code linked to means.