### PR TITLE
MINOR: Remove test scoping for common-utils dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,11 +126,6 @@
         </dependency>
         <!-- Inherited unnecessarily, scope to test so it's not packaged -->
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>common-utils</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
The `common-utils` artifact is actually required at runtime and not, as the comment above it in the POM implies, inherited unnecessarily. The dependency chain goes from the Avro converter (which is used to convert generated Avro data into a format usable for Connect records) to the `io.confluent:common-config` artifact to the `common-utils` artifact. As a result, if this artifact is not included in the plugin archive for this connector and is not present on the Connect worker's classpath, the connector will fail.

The changes here remove the custom scoping for the `common-utils` artifact, which causes it to be included in the Confluent Hub archive file and allows this connector to be used as an isolated plugin that does not rely on dependencies being present in the Connect worker's classpath.