### PR TITLE
CC-7254: Remove AvroConverter plugin from Confluent Hub archive

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,6 +207,45 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>truezip-maven-plugin</artifactId>
+                <version>1.2</version>
+                <executions>
+                    <execution>
+                        <id>remove-avro-converter-plugin</id>
+                        <goals>
+                            <goal>remove</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <fileset>
+                                <directory>${project.basedir}/target/components/packages/confluentinc-kafka-connect-datagen-${project.version}/confluentinc-kafka-connect-datagen-${project.version}/lib/kafka-connect-avro-converter-${confluent.version}.jar</directory>
+                                <includes>
+                                    <include>io/confluent/connect/avro/AvroConverter.class</include>
+                                    <include>io/confluent/connect/avro/AvroConverter$*.class</include>
+                                </includes>
+                            </fileset>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>repackage-avro-converter-dependency</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>package</phase>
+                        <configuration>
+                            <fileset>
+                                <directory>${project.basedir}/target/components/packages/confluentinc-kafka-connect-datagen-${project.version}</directory>
+                                <includes>
+                                    <include>confluentinc-kafka-connect-datagen-${project.version}/lib/kafka-connect-avro-converter-${confluent.version}.jar</include>
+                                </includes>
+                                <outputDirectory>${project.basedir}/target/components/packages/confluentinc-kafka-connect-datagen-${project.version}.zip</outputDirectory>
+                            </fileset>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The `kafka-connect-avro-converter` dependency is added to the POM for this connector so that the `AvroData` class can be used to convert from Avro to the Connect record format, but the actual `AvroConverter` class (or any of its nested classes) is never used. However, the Connect framework will still sometimes pick up the `AvroConverter` present in the plugin archive for the datagen connector and try to use that as an actual converter plugin, even though most of the transitive dependencies for the `kafka-connect-avro-converter` dependency are excluded, which then causes classloading issues.
The changes here are a bit of a hack: they alter the Confluent Hub archive generated during the connector build by removing the `AvroConverter` class (and all of its nested classes) from the `kafka-connect-avro-converter` JAR file, so that the converter is never picked up as a plugin by the Connect framework.
We could consider publishing the `AvroData` class as a separate Maven artifact so that people could add it as a dependency to their project without risk of this happening, but in the meantime, here's a quick-and-dirty solution that allows the connector to work alongside the Avro converter when both are loaded using the plugin path mechanism in Connect.