### PR TITLE
update default datagen version in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ check-dependencies:
 	@#(call check-dependency,sed)
 
 CP_VERSION ?= 5.3.1
-KAFKA_CONNECT_DATAGEN_VERSION ?= 0.1.5
+KAFKA_CONNECT_DATAGEN_VERSION ?= 0.1.6
 AGGREGATE_VERSION = $(KAFKA_CONNECT_DATAGEN_VERSION)-$(CP_VERSION)
 
 KAFKA_CONNECT_DATAGEN_LOCAL_VERSION = $(shell make local-package-version)

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 # Versions
 
 There are multiple [released versions](https://github.com/confluentinc/kafka-connect-datagen/releases) of this connector, starting with `0.1.0`.
-The instructions below use version `0.1.5` as an example, but you can substitute any of the other released versions.
+The instructions below use version `0.1.6` as an example, but you can substitute any of the other released versions.
 In fact, unless specified otherwise, we recommend using the latest released version to get all of the features and bug fixes.
 
 # Usage
@@ -28,7 +28,7 @@ Using the [Confluent Hub Client](https://docs.confluent.io/current/connect/manag
 To install a specific release version you can run: 
 
 ```bash
-confluent-hub install confluentinc/kafka-connect-datagen:0.1.5
+confluent-hub install confluentinc/kafka-connect-datagen:0.1.6
 ```
 
 or to install the latest released version:
@@ -57,7 +57,7 @@ You can create a Docker image packaged with the locally built source by running:
 make build-docker-from-local
 ```
 
-This will build the connector from source and create a local image with an aggregate version number.  The aggregate version number is the kafka-connect-datagen connector version number and the Confluent Platform version number separated with a `-`.   The local kafka-connect-datagen version number is defined in the `pom.xml` file, and the Confluent Platform version defined in the [Makefile](Makfile).  An example of the aggregate version number might be: `0.1.5-5.3.1`.
+This will build the connector from source and create a local image with an aggregate version number.  The aggregate version number is the kafka-connect-datagen connector version number and the Confluent Platform version number separated with a `-`.   The local kafka-connect-datagen version number is defined in the `pom.xml` file, and the Confluent Platform version defined in the [Makefile](Makfile).  An example of the aggregate version number might be: `0.1.6-5.3.1`.
 
 Alternatively, you can install the `kafka-connect-datagen` connector from [Confluent Hub](https://www.confluent.io/connector/kafka-connect-datagen/) into a Docker image by running:
 ```bash
@@ -68,7 +68,7 @@ The [Makefile](Makefile) contains some default variables that affect the version
 
 ```bash
 CP_VERSION ?= 5.3.1
-KAFKA_CONNECT_DATAGEN_VERSION ?= 0.1.5
+KAFKA_CONNECT_DATAGEN_VERSION ?= 0.1.6
 ```
 These values can be overriden with variable declarations before the `make` command.  For example:
 ```bash
@@ -86,12 +86,12 @@ docker-compose exec connect kafka-console-consumer --topic pageviews --bootstrap
 ```
 ## Building
 
-To build the `kafka-connect-datagen` connector from latest code and install it to a local Confluent Platform, you can perform the following (here we use `v0.1.5` to reference the git tag for the `0.1.5` version, but the same pattern works for all released versions).
+To build the `kafka-connect-datagen` connector from latest code and install it to a local Confluent Platform, you can perform the following (here we use `v0.1.6` to reference the git tag for the `0.1.6` version, but the same pattern works for all released versions).
 
 ```bash
-git checkout v0.1.5
+git checkout v0.1.6
 make package
-confluent-hub install target/components/packages/confluentinc-kafka-connect-datagen-0.1.5.zip
+confluent-hub install target/components/packages/confluentinc-kafka-connect-datagen-0.1.6.zip
 ```
 
 # Configuration
@@ -193,7 +193,7 @@ The [Makefile](Makefile) contains some default variables that affect the version
 
 ```bash
 CP_VERSION ?= 5.3.1
-KAFKA_CONNECT_DATAGEN_VERSION ?= 0.1.5
+KAFKA_CONNECT_DATAGEN_VERSION ?= 0.1.6
 ```
 
 To publish the https://hub.docker.com/r/cnfldemos/kafka-connect-datagen/ image:


### PR DESCRIPTION
Makefile defaults a kafka connect datagen version, updated to our latest build