### PR TITLE
[DO NOT MERGE] CC-7063: Bump CP parent version, upgrade to Avro 1.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>5.1.0</version>
+        <version>5.4.0</version>
     </parent>
 
     <groupId>io.confluent.kafka.connect</groupId>
@@ -31,10 +31,8 @@
 
     <properties>
         <connect-runtime-version>2.0.0</connect-runtime-version>
-        <confluent.version>5.1.0</confluent.version>
-        <confluent.avro.generator.version>0.2.0</confluent.avro.generator.version>
+        <confluent.avro.generator.version>0.2.4</confluent.avro.generator.version>
         <junit.version>4.12</junit.version>
-        <avro.version>1.8.1</avro.version>
         <licenses.version>5.1.0</licenses.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     </properties>


### PR DESCRIPTION
[Jira](https://confluentinc.atlassian.net/browse/CC-7063)

This shouldn't be merged until CP 5.4 is released, as well as version 2.4 of the Avro Random Generator.