### PR TITLE
CC-7434: Infer key schemas from value schemas, change default key schema

### DIFF
--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
@@ -46,7 +46,7 @@ public class DatagenTask extends SourceTask {
 
   static final Logger log = LoggerFactory.getLogger(DatagenTask.class);
 
-  private static final Schema KEY_SCHEMA = Schema.STRING_SCHEMA;
+  private static final Schema DEFAULT_KEY_SCHEMA = Schema.OPTIONAL_STRING_SCHEMA;
   public static final String TASK_ID = "task.id";
   public static final String TASK_GENERATION = "task.generation";
   public static final String CURRENT_ITERATION = "current.iteration";
@@ -207,13 +207,12 @@ public class DatagenTask extends SourceTask {
     }
 
     // Key
-    String keyString = "";
+    SchemaAndValue key = new SchemaAndValue(DEFAULT_KEY_SCHEMA, null);
     if (!schemaKeyField.isEmpty()) {
-      SchemaAndValue schemaAndValue = avroData.toConnectData(
+      key = avroData.toConnectData(
           randomAvroMessage.getSchema().getField(schemaKeyField).schema(),
           randomAvroMessage.get(schemaKeyField)
       );
-      keyString = schemaAndValue.value().toString();
     }
 
     // Value
@@ -251,8 +250,8 @@ public class DatagenTask extends SourceTask {
         sourceOffset,
         topic,
         null,
-        KEY_SCHEMA,
-        keyString,
+        key.schema(),
+        key.value(),
         messageSchema,
         messageValue,
         null,

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
@@ -203,6 +203,7 @@ public class DatagenTaskTest {
   private void assertRecordsMatchSchemas() {
     for (SourceRecord record : records) {
       // Check the key
+      assertEquals(expectedKeyConnectSchema.name(), record.keySchema().name());
       assertEquals(expectedKeyConnectSchema, record.keySchema());
       if (expectedKeyConnectSchema != null) {
         assertTrue(isConnectInstance(record.key(), expectedKeyConnectSchema));
@@ -321,15 +322,15 @@ public class DatagenTaskTest {
     org.apache.avro.Schema expectedValueAvroSchema = loadAvroSchema(schemaResourceFilename);
     expectedValueConnectSchema = AVRO_DATA.toConnectSchema(expectedValueAvroSchema);
 
+    // Datagen defaults to an optional string key schema if a key field is not specified
+    expectedKeyConnectSchema = Schema.OPTIONAL_STRING_SCHEMA;
+
     if (idFieldName != null) {
       // Check that the Avro schema has the named field
       org.apache.avro.Schema expectedKeyAvroSchema = expectedValueAvroSchema.getField(idFieldName).schema();
       assertNotNull(expectedKeyAvroSchema);
       expectedKeyConnectSchema = AVRO_DATA.toConnectSchema(expectedKeyAvroSchema);
     }
-
-    // Right now, Datagen always uses non-null strings for the key!
-    expectedKeyConnectSchema = Schema.STRING_SCHEMA;
   }
 
   private org.apache.avro.Schema loadAvroSchema(String schemaFilename) {


### PR DESCRIPTION
The key schema is hard-coded as STRING_SCHEMA, specifically non-optional.
This makes it impossible to specify `null` as a key, to trigger round-robin/sticky partitioning.
It also forces the key field to always refer to a string field, and not a more complex key.

This change infers the schemas from the key field itself, or defaults to
OPTIONAL_STRING_SCHEMA schema and null value for the key if no field is specified.

The test infrastructure for this was already included, but was disabled because this feature was not implemented.

Signed-off-by: Greg Harris <gregh@confluent.io>