### PR TITLE
DEVX-1923: Add missing quickstarts (Inventory and Product)

### DIFF
--- a/config/connector_inventory.config
+++ b/config/connector_inventory.config
@@ -1,0 +1,14 @@
+{
+  "name": "datagen-inventory",
+  "config": {
+    "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+    "kafka.topic": "inventory",
+    "quickstart": "inventory",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "max.interval": 1000,
+    "iterations": 10000000,
+    "tasks.max": "1"
+  }
+}

--- a/config/connector_product.config
+++ b/config/connector_product.config
@@ -1,0 +1,14 @@
+{
+  "name": "datagen-product",
+  "config": {
+    "connector.class": "io.confluent.kafka.connect.datagen.DatagenConnector",
+    "kafka.topic": "product",
+    "quickstart": "product",
+    "key.converter": "org.apache.kafka.connect.storage.StringConverter",
+    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+    "value.converter.schemas.enable": "false",
+    "max.interval": 1000,
+    "iterations": 10000000,
+    "tasks.max": "1"
+  }
+}

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
@@ -79,7 +79,9 @@ public class DatagenTask extends SourceTask {
     USERS("users_schema.avro", "userid"),
     USERS_("users_array_map_schema.avro", "userid"),
     PAGEVIEWS("pageviews_schema.avro", "viewtime"),
-    STOCK_TRADES("stock_trades_schema.avro", "symbol");
+    STOCK_TRADES("stock_trades_schema.avro", "symbol"),
+    INVENTORY("inventory.avro", "id"),
+    PRODUCT("product.avro", "id");
 
     private final String schemaFilename;
     private final String keyName;

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
@@ -123,6 +123,16 @@ public class DatagenTaskTest {
   }
 
   @Test
+  public void shouldGenerateFilesForProductQuickstart() throws Exception {
+    generateAndValidateRecordsFor(Quickstart.PRODUCT);
+  }
+
+  @Test
+  public void shouldGenerateFilesForInventoryQuickstart() throws Exception {
+    generateAndValidateRecordsFor(Quickstart.INVENTORY);
+  }
+
+  @Test
   public void shouldRestoreFromSourceOffsets() throws Exception {
     // Give the task an arbitrary source offset
     sourceOffsets = new HashMap<>();


### PR DESCRIPTION
Adds missing quickstarts

Adds enum values for missing quickstarts and tests.

## Test Strategy
* Added two unit tests to verify.
* Added two sample configs, and verified with local confluent platform 5.5.1

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests