### PR TITLE
DEVX-2070: Changes prior to building and publishing new 6.0 based datagen images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>5.5.0</version>
+        <version>6.0.0</version>
     </parent>
 
     <groupId>io.confluent.kafka.connect</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -106,12 +106,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>io.confluent.avro</groupId>
             <artifactId>avro-random-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
         <connect-runtime-version>2.0.0</connect-runtime-version>
         <confluent.avro.generator.version>0.3.1</confluent.avro.generator.version>
         <junit.version>4.12</junit.version>
+        <guava.version>29.0-jre</guava.version>
         <avro.version>1.8.1</avro.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     </properties>
@@ -110,6 +111,11 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
@@ -373,10 +373,11 @@ public class DatagenTaskTest {
 
   private org.apache.avro.Schema loadAvroSchema(String schemaFilename) {
     try {
-      Generator generator = new Generator(
-          getClass().getClassLoader().getResourceAsStream(schemaFilename),
-          new Random()
-      );
+      InputStream schemaStream = getClass().getClassLoader().getResourceAsStream(schemaFilename);
+      Generator generator = new Generator.Builder()
+              .schemaStream(schemaStream)
+              .random(new Random())
+              .generation(0L).build();
       return generator.schema();
     } catch (IOException e) {
       throw new ConnectException("Unable to read the '" + schemaFilename + "' schema file", e);

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
@@ -374,7 +374,7 @@ public class DatagenTaskTest {
   private org.apache.avro.Schema loadAvroSchema(String schemaFilename) {
     try {
       InputStream schemaStream = getClass().getClassLoader().getResourceAsStream(schemaFilename);
-      return org.apache.avro.Schema.Parser().parse(schemaStream);
+      return (new org.apache.avro.Schema.Parser()).parse(schemaStream);
     } catch (IOException e) {
       throw new ConnectException("Unable to read the '" + schemaFilename + "' schema file", e);
     }

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
@@ -374,11 +374,7 @@ public class DatagenTaskTest {
   private org.apache.avro.Schema loadAvroSchema(String schemaFilename) {
     try {
       InputStream schemaStream = getClass().getClassLoader().getResourceAsStream(schemaFilename);
-      Generator generator = new Generator.Builder()
-              .schemaStream(schemaStream)
-              .random(new Random())
-              .generation(0L).build();
-      return generator.schema();
+      return org.apache.avro.Schema.Parser().parse(schemaStream);
     } catch (IOException e) {
       throw new ConnectException("Unable to read the '" + schemaFilename + "' schema file", e);
     }


### PR DESCRIPTION
## Problem
Want to build a new version of the connector off of the 6.0 CP libraries

## Solution
Update pom.xml and execute a release building 0.3.4 datagen version

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

## Test Strategy
No code changes in the datagen code with this change, only the base libraries have been upgraded to 6.0.  Unit tests pass

## Release Plan
After building the full datagen docker imags, will validate new images in Confluent Integration Arch demos and examples. 
