### PR TITLE
DEVX-2372: Build and publish new kafka-connect-datagen 6.1.0 images and update all demos on 6.1.0-post branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL=/bin/bash -o pipefail
 
 check-dependency = $(if $(shell command -v $(1)),,$(error Make sure $(1) is installed))
 
-CP_VERSION ?= 6.0.1
+CP_VERSION ?= 6.1.0
 OPERATOR_VERSION ?= 0
 
 KAFKA_CONNECT_DATAGEN_VERSION ?= 0.4.0

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ You can create a Docker image packaged with the locally built source by running 
 make build-docker-from-local CP_VERSION=5.5.0
 ```
 
-This will build the connector from source and create a local image with an aggregate version number.  The aggregate version number is the kafka-connect-datagen connector version number and the Confluent Platform version number separated with a `-`.   The local kafka-connect-datagen version number is defined in the `pom.xml` file, and the Confluent Platform version defined in the [Makefile](Makfile).  An example of the aggregate version number might be: `0.4.0-6.0.1`.
+This will build the connector from source and create a local image with an aggregate version number.  The aggregate version number is the kafka-connect-datagen connector version number and the Confluent Platform version number separated with a `-`.   The local kafka-connect-datagen version number is defined in the `pom.xml` file, and the Confluent Platform version defined in the [Makefile](Makfile).  An example of the aggregate version number might be: `0.4.0-6.1.0`.
 
 Alternatively, you can install the `kafka-connect-datagen` connector from [Confluent Hub](https://www.confluent.io/connector/kafka-connect-datagen/) into a Docker image by running:
 ```bash
@@ -80,7 +80,7 @@ make build-docker-from-released CP_VERSION=5.5.0
 The [Makefile](Makefile) contains some default variables that affect the version numbers of both the installed `kafka-connect-datagen` as well as the base Confluent Platform version.  The variables are located near the top of the [Makefile](Makefile) with the following names and current default values:
 
 ```bash
-CP_VERSION ?= 6.0.1
+CP_VERSION ?= 6.1.0
 
 KAFKA_CONNECT_DATAGEN_VERSION ?= 0.4.0
 ```
@@ -238,7 +238,7 @@ To release new versions of the Docker images to Dockerhub (https://hub.docker.co
 The [Makefile](Makefile) contains some default variables that affect the version numbers of both the installed `kafka-connect-datagen` as well as the base Confluent Platform version.  The variables are located near the top of the [Makefile](Makefile) with the following names and current default values:
 
 ```bash
-CP_VERSION ?= 6.0.1
+CP_VERSION ?= 6.1.0
 KAFKA_CONNECT_DATAGEN_VERSION ?= 0.4.0
 OPERATOR_VERSION ?= 0 # Operator is a 'rev' version appended at the end of the CP version, like so: 5.5.0.0
 ```


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/DEVX-2372

Branch and DEVX Jira tickets are off, apologies. Created image locally and tested with examples/ccloud, and cp-all-in-one-community. 

@ybyzek and @rspurgeon One question prior to officially submitting this PR--can we push new versions of the connector to confluent hub? Should I update the pom.xml confluent version and package version in this PR even though I may not be able to publish those packages to confluent hub? For the record, I was able to update the pom.xml (minor change necessary `confluent.version` --> `confluent.version.range`), and create the package. All tests passed during compiling. 

Also is here when I should update the docker-compose? That looks pretty out of date. 

Will publish images once merged (ie run `make push-from-released`, `make push-cp-server-conect-from-released`, and `make push-cp-server-connect-operator-from-released`).

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
