### PR TITLE
Fail with appropriate message instead of aborting with NPE when field specified in schema.keyfield doesn't exist in the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ For an example of using the the Protobuf converter with kafka-connect-datagen, s
 ## Use a bundled schema specification
 
 There are a few quickstart schema specifications bundled with `kafka-connect-datagen`, and they are listed in this [directory](https://github.com/confluentinc/kafka-connect-datagen/tree/master/src/main/resources).
-To use one of these bundled schema, refer to [this mapping](https://github.com/confluentinc/kafka-connect-datagen/blob/master/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java#L66-L73) and in the configuration file, set the parameter `quickstart` to the associated name.
+To use one of these bundled schema, refer to [this mapping](https://github.com/confluentinc/kafka-connect-datagen/blob/master/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java#L75-L86) and in the configuration file, set the parameter `quickstart` to the associated name.
 For example:
 
 ```bash

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
@@ -31,6 +31,7 @@ import io.confluent.avro.random.generator.Generator;
 import io.confluent.connect.avro.AvroData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.header.ConnectHeaders;
@@ -182,6 +183,12 @@ public class DatagenTask extends SourceTask {
     }
 
     avroSchema = generator.schema();
+
+    if (!schemaKeyField.isEmpty() && avroSchema.getField(schemaKeyField) == null) {
+      throw new ConfigException(DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF, schemaKeyField,
+              "Schema does not contain the specified field");
+    }
+
     avroData = new AvroData(1);
     ksqlSchema = avroData.toConnectSchema(avroSchema);
   }

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
@@ -35,6 +35,7 @@ import io.confluent.connect.avro.AvroData;
 
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
@@ -125,6 +126,8 @@ public class DatagenTaskTest {
   public void shouldGenerateFilesForStockTradesQuickstart() throws Exception {
     generateAndValidateRecordsFor(DatagenTask.Quickstart.STOCK_TRADES);
   }
+
+  @Test
   public void shouldGenerateFilesForProductQuickstart() throws Exception {
     generateAndValidateRecordsFor(Quickstart.PRODUCT);
   }
@@ -199,6 +202,14 @@ public class DatagenTaskTest {
     } catch (ConnectException e) {
       // expected
     }
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldFailIfSchemaKeyFieldNotPresentInSchema() throws Exception {
+    config.put(DatagenConnectorConfig.QUICKSTART_CONF, DatagenTask.Quickstart.USERS.name());
+    config.put(DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF, "key_does_not_exist");
+    createTask();
+    generateRecords();
   }
 
   private void generateAndValidateRecordsFor(DatagenTask.Quickstart quickstart) throws Exception {


### PR DESCRIPTION
## Problem
https://github.com/confluentinc/kafka-connect-datagen/issues/29

## Solution
Add an explicit check to see if field specified in config `schema.keyfield` exists in the provided schema. If it isn't present, throw an appropriate error instead of failing with a [NPE here](https://github.com/confluentinc/kafka-connect-datagen/blob/c661b0d76eab491d2d9dfe6a1482c65141caaea6/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java#L227)

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
Added a unit test

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Open Questions / Follow up

- Should we add a config validation for this? We'd probably need to add some schema parsing and validation too. Currently, the only validation that exists is a check to verify that not more than 1 out of `schema.filename`, `schema.string` and `quickstart` is set. If a bad schema is provided, the connector will start and immediately fail. 