### PR TITLE
Add validations for quickstart, schema.string, schema.filename

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
         <guava.version>29.0-jre</guava.version>
         <avro.version>1.8.1</avro.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
+        <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
+            See https://github.com/confluentinc/common/pull/332 for details -->
+        <dependency.check.version>6.1.6</dependency.check.version>
     </properties>
 
     <name>kafka-connect-datagen</name>

--- a/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+
+package io.confluent.kafka.connect.datagen;
+
+import io.confluent.kafka.connect.datagen.DatagenTask.Quickstart;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Parser;
+import org.apache.avro.SchemaParseException;
+import org.apache.kafka.common.config.ConfigException;
+
+public class ConfigUtils {
+  public static Schema getSchemaFromQuickstart(String quickstart) {
+    String schemaFilename = Quickstart.valueOf(quickstart.toUpperCase()).getSchemaFilename();
+    return getSchemaFromSchemaFileName(schemaFilename);
+  }
+
+  public static Schema getSchemaFromSchemaString(String schemaString) {
+    Schema.Parser schemaParser = new Parser();
+    Schema schema;
+    try {
+      schema = schemaParser.parse(schemaString);
+    } catch (SchemaParseException e) {
+      throw new ConfigException("Unable to parse the provided schema");
+    }
+    return schema;
+  }
+
+  public static Schema getSchemaFromSchemaFileName(String schemaFileName) {
+    Schema.Parser schemaParser = new Parser();
+    Schema schema;
+    try {
+      InputStream stream = new FileInputStream(schemaFileName);
+      schema = schemaParser.parse(stream);
+    } catch (FileNotFoundException e) {
+      try {
+        if (DatagenTask.class.getClassLoader()
+            .getResource(schemaFileName) == null) {
+          throw new ConfigException("Unable to parse the provided schema");
+        }
+        schema = schemaParser.parse(DatagenTask.class.getClassLoader()
+          .getResourceAsStream(schemaFileName));
+      } catch (SchemaParseException | IOException i) {
+        throw new ConfigException("Unable to parse the provided schema");
+      }
+    } catch (SchemaParseException | IOException e) {
+      throw new ConfigException("Unable to parse the provided schema");
+    }
+    return schema;
+  }
+}

--- a/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
@@ -16,7 +16,6 @@
 
 package io.confluent.kafka.connect.datagen;
 
-import io.confluent.kafka.connect.datagen.DatagenTask.Quickstart;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -27,11 +26,6 @@ import org.apache.avro.SchemaParseException;
 import org.apache.kafka.common.config.ConfigException;
 
 public class ConfigUtils {
-  public static Schema getSchemaFromQuickstart(String quickstart) {
-    String schemaFilename = Quickstart.valueOf(quickstart.toUpperCase()).getSchemaFilename();
-    return getSchemaFromSchemaFileName(schemaFilename);
-  }
-
   public static Schema getSchemaFromSchemaString(String schemaString) {
     Schema.Parser schemaParser = new Parser();
     Schema schema;
@@ -53,10 +47,11 @@ public class ConfigUtils {
       try {
         if (DatagenTask.class.getClassLoader()
             .getResource(schemaFileName) == null) {
-          throw new ConfigException("Unable to parse the provided schema");
+          throw new ConfigException("Unable to find the schema file");
         }
-        schema = schemaParser.parse(DatagenTask.class.getClassLoader()
-          .getResourceAsStream(schemaFileName));
+        schema = schemaParser.parse(
+          DatagenTask.class.getClassLoader().getResourceAsStream(schemaFileName)
+        );
       } catch (SchemaParseException | IOException i) {
         throw new ConfigException("Unable to parse the provided schema");
       }

--- a/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
@@ -24,14 +24,19 @@ import org.apache.avro.Schema;
 import org.apache.avro.Schema.Parser;
 import org.apache.avro.SchemaParseException;
 import org.apache.kafka.common.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ConfigUtils {
+  private static final Logger log = LoggerFactory.getLogger(ConfigUtils.class);
+
   public static Schema getSchemaFromSchemaString(String schemaString) {
     Schema.Parser schemaParser = new Parser();
     Schema schema;
     try {
       schema = schemaParser.parse(schemaString);
     } catch (SchemaParseException e) {
+      log.error("Unable to parse the provided schema", e);
       throw new ConfigException("Unable to parse the provided schema");
     }
     return schema;
@@ -40,8 +45,7 @@ public class ConfigUtils {
   public static Schema getSchemaFromSchemaFileName(String schemaFileName) {
     Schema.Parser schemaParser = new Parser();
     Schema schema;
-    try {
-      InputStream stream = new FileInputStream(schemaFileName);
+    try (InputStream stream = new FileInputStream(schemaFileName)) {
       schema = schemaParser.parse(stream);
     } catch (FileNotFoundException e) {
       try {
@@ -53,9 +57,11 @@ public class ConfigUtils {
           DatagenTask.class.getClassLoader().getResourceAsStream(schemaFileName)
         );
       } catch (SchemaParseException | IOException i) {
+        log.error("Unable to parse the provided schema", i);
         throw new ConfigException("Unable to parse the provided schema");
       }
     } catch (SchemaParseException | IOException e) {
+      log.error("Unable to parse the provided schema", e);
       throw new ConfigException("Unable to parse the provided schema");
     }
     return schema;

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnector.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnector.java
@@ -16,13 +16,12 @@
 
 package io.confluent.kafka.connect.datagen;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
 import java.util.stream.Collectors;
+import org.apache.avro.Schema;
 import org.apache.kafka.common.config.Config;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigException;
@@ -37,10 +36,6 @@ public class DatagenConnector extends SourceConnector {
   private static Logger log = LoggerFactory.getLogger(DatagenConnector.class);
   private DatagenConnectorConfig config;
   private Map<String, String> props;
-
-  @VisibleForTesting
-  static final String SCHEMA_SOURCE_ERR =
-      "Must set exactly one of " + String.join(", ", DatagenConnectorConfig.schemaSourceKeys());
 
   @Override
   public String version() {
@@ -88,23 +83,64 @@ public class DatagenConnector extends SourceConnector {
   @Override
   public Config validate(Map<String, String> connectorConfigs) {
     Config config = super.validate(connectorConfigs);
-    validateSchemaSource(config);
+    boolean isSingleSchemaSource = validateSchemaSource(config);
+    boolean hasSchemaSourceErrors = hasSchemaSourceErrors(config);
+
+    // skip further validations if any single config validations have failed
+    try {
+      this.config = new DatagenConnectorConfig(connectorConfigs);
+    } catch (ConfigException e) {
+      return config;
+    }
+
+    if (isSingleSchemaSource && !hasSchemaSourceErrors) {
+      validateSchemaKeyField(config, this.config.getSchema());
+    }
     return config;
   }
 
-  private void validateSchemaSource(Config config) {
+  private boolean validateSchemaSource(Config config) {
     List<ConfigValue> schemaSources = config.configValues().stream()
         .filter(v -> DatagenConnectorConfig.isExplicitlySetSchemaSource(v.name(), v.value()))
         .collect(Collectors.toList());
+    String schemaSourceError = "Must set exactly one of "
+            + String.join(", ", DatagenConnectorConfig.schemaSourceKeys());
     if (schemaSources.size() > 1) {
       for (ConfigValue v : schemaSources) {
-        v.addErrorMessage(SCHEMA_SOURCE_ERR);
+        v.addErrorMessage(schemaSourceError);
       }
+      return false;
     }
     if (schemaSources.size() == 0) {
       config.configValues().stream()
           .filter(v -> DatagenConnectorConfig.schemaSourceKeys().contains(v.name()))
-          .forEach(v -> v.addErrorMessage(SCHEMA_SOURCE_ERR));
+          .forEach(v -> v.addErrorMessage(schemaSourceError));
+      return false;
     }
+    return true;
+  }
+
+  private boolean hasSchemaSourceErrors(Config config) {
+    return config.configValues().stream()
+            .filter(v -> DatagenConnectorConfig.isExplicitlySetSchemaSource(v.name(), v.value()))
+            .anyMatch(v -> v.errorMessages().size() > 0);
+  }
+
+  private void validateSchemaKeyField(Config config, Schema schema) {
+    ConfigValue schemaKeyField = getConfigValue(config,
+            DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF);
+
+    if (schemaKeyField != null && !schemaKeyField.value().equals("")) {
+      if (schema.getField((String) schemaKeyField.value()) == null) {
+        schemaKeyField.addErrorMessage("The schema does not contain the field provided in '"
+                + DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF + "'");
+      }
+    }
+  }
+
+  private ConfigValue getConfigValue(Config config, String configName) {
+    return config.configValues().stream()
+            .filter(value -> value.name().equals(configName))
+            .findFirst().orElse(null);
   }
 }

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnector.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnector.java
@@ -84,7 +84,6 @@ public class DatagenConnector extends SourceConnector {
   public Config validate(Map<String, String> connectorConfigs) {
     Config config = super.validate(connectorConfigs);
     boolean isSingleSchemaSource = validateSchemaSource(config);
-    boolean hasSchemaSourceErrors = hasSchemaSourceErrors(config);
 
     // skip further validations if any single config validations have failed
     try {
@@ -93,7 +92,7 @@ public class DatagenConnector extends SourceConnector {
       return config;
     }
 
-    if (isSingleSchemaSource && !hasSchemaSourceErrors) {
+    if (isSingleSchemaSource) {
       validateSchemaKeyField(config, this.config.getSchema());
     }
     return config;
@@ -120,20 +119,17 @@ public class DatagenConnector extends SourceConnector {
     return true;
   }
 
-  private boolean hasSchemaSourceErrors(Config config) {
-    return config.configValues().stream()
-            .filter(v -> DatagenConnectorConfig.isExplicitlySetSchemaSource(v.name(), v.value()))
-            .anyMatch(v -> v.errorMessages().size() > 0);
-  }
-
   private void validateSchemaKeyField(Config config, Schema schema) {
-    ConfigValue schemaKeyField = getConfigValue(config,
-            DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF);
+    ConfigValue schemaKeyField = getConfigValue(
+        config,
+        DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF
+    );
 
     if (schemaKeyField != null && !schemaKeyField.value().equals("")) {
       if (schema.getField((String) schemaKeyField.value()) == null) {
-        schemaKeyField.addErrorMessage("The schema does not contain the field provided in '"
-                + DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF + "'");
+        schemaKeyField.addErrorMessage(
+            "The schema does not contain the field provided in '"
+              + DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF + "'");
       }
     }
   }

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnector.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnector.java
@@ -129,7 +129,8 @@ public class DatagenConnector extends SourceConnector {
       if (schema.getField((String) schemaKeyField.value()) == null) {
         schemaKeyField.addErrorMessage(
             "The schema does not contain the field provided in '"
-              + DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF + "'");
+              + DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF + "'"
+        );
       }
     }
   }

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnectorConfig.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnectorConfig.java
@@ -63,13 +63,33 @@ public class DatagenConnectorConfig extends AbstractConfig {
         .define(KAFKA_TOPIC_CONF, Type.STRING, Importance.HIGH, KAFKA_TOPIC_DOC)
         .define(MAXINTERVAL_CONF, Type.LONG, 500L, Importance.HIGH, MAXINTERVAL_DOC)
         .define(ITERATIONS_CONF, Type.INT, -1, Importance.HIGH, ITERATIONS_DOC)
-        .define(SCHEMA_STRING_CONF, Type.STRING, "", new SchemaStringValidator(),
-                Importance.HIGH, SCHEMA_STRING_DOC)
-        .define(SCHEMA_FILENAME_CONF, Type.STRING, "", new SchemaFileValidator(),
-                Importance.HIGH, SCHEMA_FILENAME_DOC)
-        .define(SCHEMA_KEYFIELD_CONF, Type.STRING, "", Importance.HIGH, SCHEMA_KEYFIELD_DOC)
-        .define(QUICKSTART_CONF, Type.STRING, "", new QuickstartValidator(),
-                Importance.HIGH, QUICKSTART_DOC)
+        .define(SCHEMA_STRING_CONF,
+          Type.STRING,
+          "",
+          new SchemaStringValidator(),
+          Importance.HIGH,
+          SCHEMA_STRING_DOC
+        )
+        .define(SCHEMA_FILENAME_CONF,
+          Type.STRING,
+          "",
+          new SchemaFileValidator(),
+          Importance.HIGH,
+          SCHEMA_FILENAME_DOC
+        )
+        .define(SCHEMA_KEYFIELD_CONF,
+          Type.STRING,
+          "",
+          Importance.HIGH,
+          SCHEMA_KEYFIELD_DOC
+        )
+        .define(QUICKSTART_CONF,
+          Type.STRING,
+          "",
+          new QuickstartValidator(),
+          Importance.HIGH,
+          QUICKSTART_DOC
+        )
         .define(RANDOM_SEED_CONF, Type.LONG, null, Importance.LOW, RANDOM_SEED_DOC);
   }
 
@@ -111,18 +131,11 @@ public class DatagenConnectorConfig extends AbstractConfig {
     return this.getString(SCHEMA_STRING_CONF);
   }
 
-  public static List<String> schemaSourceKeys() {
-    return ImmutableList.of(SCHEMA_STRING_CONF, SCHEMA_FILENAME_CONF, QUICKSTART_CONF);
-  }
-
-  public static boolean isExplicitlySetSchemaSource(String key, Object value) {
-    return schemaSourceKeys().contains(key) && !("".equals(value));
-  }
-
   public Schema getSchema() {
     String quickstart = getQuickstart();
     if (quickstart != null && !quickstart.isEmpty()) {
-      return ConfigUtils.getSchemaFromQuickstart(quickstart);
+      String schemaFilename = Quickstart.valueOf(quickstart.toUpperCase()).getSchemaFilename();
+      return ConfigUtils.getSchemaFromSchemaFileName(schemaFilename);
     }
     String schemaString = getSchemaString();
     if (schemaString != null && !schemaString.isEmpty()) {
@@ -135,6 +148,14 @@ public class DatagenConnectorConfig extends AbstractConfig {
     return null;
   }
 
+  public static List<String> schemaSourceKeys() {
+    return ImmutableList.of(SCHEMA_STRING_CONF, SCHEMA_FILENAME_CONF, QUICKSTART_CONF);
+  }
+
+  public static boolean isExplicitlySetSchemaSource(String key, Object value) {
+    return schemaSourceKeys().contains(key) && !("".equals(value));
+  }
+
   private static class QuickstartValidator implements Validator {
 
     @Override
@@ -143,8 +164,8 @@ public class DatagenConnectorConfig extends AbstractConfig {
         return;
       }
       if (!Quickstart.configValues.contains(((String) value).toLowerCase())) {
-        throw new ConfigException(name + " must be one out of "
-                + String.join(",", DatagenTask.Quickstart.configValues));
+        throw new ConfigException(String.format("%s must be one out of %s",
+          name, String.join(",", DatagenTask.Quickstart.configValues)));
       }
     }
   }

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnectorConfig.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnectorConfig.java
@@ -17,13 +17,16 @@
 package io.confluent.kafka.connect.datagen;
 
 import com.google.common.collect.ImmutableList;
+import io.confluent.kafka.connect.datagen.DatagenTask.Quickstart;
 import java.util.List;
 import java.util.Map;
-
+import org.apache.avro.Schema;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Importance;
+import org.apache.kafka.common.config.ConfigDef.Type;
+import org.apache.kafka.common.config.ConfigDef.Validator;
+import org.apache.kafka.common.config.ConfigException;
 
 public class DatagenConnectorConfig extends AbstractConfig {
 
@@ -60,10 +63,13 @@ public class DatagenConnectorConfig extends AbstractConfig {
         .define(KAFKA_TOPIC_CONF, Type.STRING, Importance.HIGH, KAFKA_TOPIC_DOC)
         .define(MAXINTERVAL_CONF, Type.LONG, 500L, Importance.HIGH, MAXINTERVAL_DOC)
         .define(ITERATIONS_CONF, Type.INT, -1, Importance.HIGH, ITERATIONS_DOC)
-        .define(SCHEMA_STRING_CONF, Type.STRING, "", Importance.HIGH, SCHEMA_STRING_DOC)
-        .define(SCHEMA_FILENAME_CONF, Type.STRING, "", Importance.HIGH, SCHEMA_FILENAME_DOC)
+        .define(SCHEMA_STRING_CONF, Type.STRING, "", new SchemaStringValidator(),
+                Importance.HIGH, SCHEMA_STRING_DOC)
+        .define(SCHEMA_FILENAME_CONF, Type.STRING, "", new SchemaFileValidator(),
+                Importance.HIGH, SCHEMA_FILENAME_DOC)
         .define(SCHEMA_KEYFIELD_CONF, Type.STRING, "", Importance.HIGH, SCHEMA_KEYFIELD_DOC)
-        .define(QUICKSTART_CONF, Type.STRING, "", Importance.HIGH, QUICKSTART_DOC)
+        .define(QUICKSTART_CONF, Type.STRING, "", new QuickstartValidator(),
+                Importance.HIGH, QUICKSTART_DOC)
         .define(RANDOM_SEED_CONF, Type.LONG, null, Importance.LOW, RANDOM_SEED_DOC);
   }
 
@@ -84,6 +90,12 @@ public class DatagenConnectorConfig extends AbstractConfig {
   }
 
   public String getSchemaKeyfield() {
+    if (this.getString(SCHEMA_KEYFIELD_CONF).isEmpty()) {
+      String quickstart = this.getString(QUICKSTART_CONF);
+      if (!quickstart.isEmpty()) {
+        return Quickstart.valueOf(quickstart.toUpperCase()).getSchemaKeyField();
+      }
+    }
     return this.getString(SCHEMA_KEYFIELD_CONF);
   }
 
@@ -105,6 +117,58 @@ public class DatagenConnectorConfig extends AbstractConfig {
 
   public static boolean isExplicitlySetSchemaSource(String key, Object value) {
     return schemaSourceKeys().contains(key) && !("".equals(value));
+  }
+
+  public Schema getSchema() {
+    String quickstart = getQuickstart();
+    if (quickstart != null && !quickstart.isEmpty()) {
+      return ConfigUtils.getSchemaFromQuickstart(quickstart);
+    }
+    String schemaString = getSchemaString();
+    if (schemaString != null && !schemaString.isEmpty()) {
+      return ConfigUtils.getSchemaFromSchemaString(schemaString);
+    }
+    String schemaFileName = getSchemaFilename();
+    if (schemaFileName != null && !schemaFileName.isEmpty()) {
+      return ConfigUtils.getSchemaFromSchemaFileName(schemaFileName);
+    }
+    return null;
+  }
+
+  private static class QuickstartValidator implements Validator {
+
+    @Override
+    public void ensureValid(String name, Object value) {
+      if (((String) value).isEmpty()) {
+        return;
+      }
+      if (!Quickstart.configValues.contains(((String) value).toLowerCase())) {
+        throw new ConfigException(name + " must be one out of "
+                + String.join(",", DatagenTask.Quickstart.configValues));
+      }
+    }
+  }
+
+  private static class SchemaStringValidator implements Validator {
+
+    @Override
+    public void ensureValid(String name, Object value) {
+      if (((String) value).isEmpty()) {
+        return;
+      }
+      ConfigUtils.getSchemaFromSchemaString((String) value);
+    }
+  }
+
+  private static class SchemaFileValidator implements Validator {
+
+    @Override
+    public void ensureValid(String name, Object value) {
+      if (((String) value).isEmpty()) {
+        return;
+      }
+      ConfigUtils.getSchemaFromSchemaFileName((String) value);
+    }
   }
 }
 

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnectorConfig.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnectorConfig.java
@@ -164,8 +164,11 @@ public class DatagenConnectorConfig extends AbstractConfig {
         return;
       }
       if (!Quickstart.configValues.contains(((String) value).toLowerCase())) {
-        throw new ConfigException(String.format("%s must be one out of %s",
-          name, String.join(",", DatagenTask.Quickstart.configValues)));
+        throw new ConfigException(String.format(
+                "%s must be one out of %s",
+                name,
+                String.join(",", DatagenTask.Quickstart.configValues)
+        ));
       }
     }
   }

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
@@ -16,31 +16,28 @@
 
 package io.confluent.kafka.connect.datagen;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.FileInputStream;
+import io.confluent.avro.random.generator.Generator;
+import io.confluent.connect.avro.AvroData;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Collectors;
-
-import io.confluent.avro.random.generator.Generator;
-import io.confluent.connect.avro.AvroData;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.data.Field;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -60,10 +57,7 @@ public class DatagenTask extends SourceTask {
   private long maxInterval;
   private int maxRecords;
   private long count = 0L;
-  private String schemaFilename;
   private String schemaKeyField;
-  private String schemaString;
-  private Quickstart quickstart;
   private Generator generator;
   private org.apache.avro.Schema avroSchema;
   private org.apache.kafka.connect.data.Schema ksqlSchema;
@@ -85,6 +79,14 @@ public class DatagenTask extends SourceTask {
     STOCK_TRADES("stock_trades_schema.avro", "symbol"),
     INVENTORY("inventory.avro", "id"),
     PRODUCT("product.avro", "id");
+
+    static final Set<String> configValues = new HashSet<>();
+
+    static {
+      for (Quickstart q : Quickstart.values()) {
+        configValues.add(q.name().toLowerCase());
+      }
+    }
 
     private final String schemaFilename;
     private final String keyName;
@@ -114,8 +116,6 @@ public class DatagenTask extends SourceTask {
     topic = config.getKafkaTopic();
     maxInterval = config.getMaxInterval();
     maxRecords = config.getIterations();
-    schemaFilename = config.getSchemaFilename();
-    schemaString = config.getSchemaString();
     schemaKeyField = config.getSchemaKeyfield();
     taskGeneration = 0;
     taskId = Integer.parseInt(props.get(TASK_ID));
@@ -139,56 +139,14 @@ public class DatagenTask extends SourceTask {
       random.setSeed((Long) offset.get(RANDOM_SEED));
     }
 
+    avroSchema = config.getSchema();
+
     Generator.Builder generatorBuilder = new Generator.Builder()
         .random(random)
-        .generation(count);
-    String quickstartName = config.getQuickstart();
-    if (quickstartName != "") {
-      try {
-        quickstart = Quickstart.valueOf(quickstartName.toUpperCase());
-        if (quickstart != null) {
-          schemaFilename = quickstart.getSchemaFilename();
-          schemaKeyField = schemaKeyField.equals("")
-              ? quickstart.getSchemaKeyField() : schemaKeyField;
-          try {
-            generator = generatorBuilder
-                .schemaStream(getClass().getClassLoader().getResourceAsStream(schemaFilename))
-                .build();
-          } catch (IOException e) {
-            throw new ConnectException("Unable to read the '"
-                + schemaFilename + "' schema file", e);
-          }
-        }
-      } catch (IllegalArgumentException e) {
-        log.warn("Quickstart '{}' not found: ", quickstartName, e);
-      }
-    } else if (schemaString != "") {
-      generator = generatorBuilder.schemaString(schemaString).build();
-    } else {
-      String err = "Unable to read the '" + schemaFilename + "' schema file";
-      try {
-        generator = generatorBuilder.schemaStream(new FileInputStream(schemaFilename)).build();
-      } catch (FileNotFoundException e) {
-        // also look in jars on the classpath
-        try {
-          generator = generatorBuilder
-              .schemaStream(DatagenTask.class.getClassLoader().getResourceAsStream(schemaFilename))
-              .build();
-        } catch (IOException inner) {
-          throw new ConnectException(err, e);
-        }
-      } catch (IOException e) {
-        throw new ConnectException(err, e);
-      }
-    }
+        .generation(count)
+        .schema(avroSchema);
 
-    avroSchema = generator.schema();
-
-    if (!schemaKeyField.isEmpty() && avroSchema.getField(schemaKeyField) == null) {
-      throw new ConfigException(DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF, schemaKeyField,
-              "Schema does not contain the specified field");
-    }
-
+    generator = generatorBuilder.build();
     avroData = new AvroData(1);
     ksqlSchema = avroData.toConnectSchema(avroSchema);
   }

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenConnectorTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenConnectorTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.kafka.common.config.Config;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
@@ -75,7 +76,6 @@ public class DatagenConnectorTest {
   public void shouldAllowSettingQuickstart() {
     clearSchemaSources();
     config.put(DatagenConnectorConfig.QUICKSTART_CONF, Quickstart.USERS.name());
-
     Config validated = connector.validate(config);
 
     for (String k : DatagenConnectorConfig.schemaSourceKeys()) {
@@ -86,8 +86,10 @@ public class DatagenConnectorTest {
   @Test
   public void shouldAllowSettingSchema() {
     clearSchemaSources();
-    config.put(DatagenConnectorConfig.SCHEMA_STRING_CONF, "a schema");
-
+    config.put(DatagenConnectorConfig.SCHEMA_STRING_CONF,
+            "{\"namespace\":\"ksql\",\"name\":\"test_schema\",\"type\":\"record\",\"fields\":" +
+                    "[{\"name\":\"id\",\"type\":{\"type\":\"long\",\"arg.properties\"" +
+                    ":{\"iteration\":{\"start\":0}}}}]}");
     Config validated = connector.validate(config);
 
     for (String k : DatagenConnectorConfig.schemaSourceKeys()) {
@@ -98,8 +100,7 @@ public class DatagenConnectorTest {
   @Test
   public void shouldAllowSettingSchemaFile() {
     clearSchemaSources();
-    config.put(DatagenConnectorConfig.SCHEMA_FILENAME_CONF, "a schema file");
-
+    config.put(DatagenConnectorConfig.SCHEMA_FILENAME_CONF, "product.avro");
     Config validated = connector.validate(config);
 
     for (String k : DatagenConnectorConfig.schemaSourceKeys()) {
@@ -110,36 +111,64 @@ public class DatagenConnectorTest {
   @Test
   public void shouldFailValidationWithMultipleSchemaSources() {
     clearSchemaSources();
-    config.put(DatagenConnectorConfig.SCHEMA_STRING_CONF, "a schema");
-    config.put(DatagenConnectorConfig.SCHEMA_FILENAME_CONF, "a schema file");
-
+    config.put(DatagenConnectorConfig.SCHEMA_STRING_CONF,
+            "{\"namespace\":\"ksql\",\"name\":\"test_schema\",\"type\":\"record\",\"fields\":" +
+                    "[{\"name\":\"id\",\"type\":{\"type\":\"long\",\"arg.properties\"" +
+                    ":{\"iteration\":{\"start\":0}}}}]}");
+    config.put(DatagenConnectorConfig.SCHEMA_FILENAME_CONF, "product.avro");
     Config validated = connector.validate(config);
 
     assertThat(
         validated,
-        hasValidationError(
-            DatagenConnectorConfig.SCHEMA_STRING_CONF,
-            DatagenConnector.SCHEMA_SOURCE_ERR
-        )
+        hasValidationError(DatagenConnectorConfig.SCHEMA_STRING_CONF, 1)
     );
     assertThat(
         validated,
-        hasValidationError(
-            DatagenConnectorConfig.SCHEMA_FILENAME_CONF,
-            DatagenConnector.SCHEMA_SOURCE_ERR
-        )
+        hasValidationError(DatagenConnectorConfig.SCHEMA_FILENAME_CONF, 1)
     );
   }
 
   @Test
   public void shouldFailValidationWithNoSchemaSources() {
     clearSchemaSources();
-
     Config validated = connector.validate(config);
 
     for (String k : DatagenConnectorConfig.schemaSourceKeys()) {
-      assertThat(validated, hasValidationError(k, DatagenConnector.SCHEMA_SOURCE_ERR));
+      assertThat(validated, hasValidationError(k, 1));
     }
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldFailValidationWithInvalidSchemaString() {
+    clearSchemaSources();
+    config.put(DatagenConnectorConfig.SCHEMA_STRING_CONF, "a schema");
+    new DatagenConnectorConfig(config);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldFailValidationWithInvalidFileName() {
+    clearSchemaSources();
+    config.put(DatagenConnectorConfig.SCHEMA_FILENAME_CONF, "a file name");
+    new DatagenConnectorConfig(config);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void shouldFailValidationWithInvalidSchemaFile() {
+    clearSchemaSources();
+    config.put(DatagenConnectorConfig.SCHEMA_FILENAME_CONF, "invalid_users_schema.avro");
+    new DatagenConnectorConfig(config);
+  }
+
+  @Test
+  public void shouldFailValidationWithInvalidSchemaKeyField() {
+    clearSchemaSources();
+    config.put(DatagenConnectorConfig.SCHEMA_FILENAME_CONF, "product.avro");
+    config.put(DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF, "key_does_not_exist");
+    Config validated = connector.validate(config);
+    assertThat(
+            validated,
+            hasValidationError(DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF, 1)
+    );
   }
 
   protected void assertTaskConfigs(int maxTasks) {
@@ -199,23 +228,23 @@ public class DatagenConnectorTest {
     }
   }
 
-  private Matcher<Config> hasValidationError(String key, String error) {
-    return new HasValidationError(key, error);
+  private Matcher<Config> hasValidationError(String key, Integer errorCount) {
+    return new HasValidationError(key, errorCount);
   }
 
   private static class HasValidationError extends TypeSafeMatcher<Config> {
     final String key;
-    final String error;
+    final Integer errorCount;
 
-    private HasValidationError(String key, String error) {
+    private HasValidationError(String key, Integer errorCount) {
       this.key = Objects.requireNonNull(key, "key");
-      this.error = Objects.requireNonNull(error, "error");
+      this.errorCount = Objects.requireNonNull(errorCount, "errorCount");
     }
 
     @Override
     protected boolean matchesSafely(Config config) {
       Optional<ConfigValue> value = value(config);
-      return value.isPresent() && value.get().errorMessages().contains(error);
+      return value.isPresent() && value.get().errorMessages().size() == errorCount;
     }
 
     @Override

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
@@ -204,14 +204,6 @@ public class DatagenTaskTest {
     }
   }
 
-  @Test(expected = ConfigException.class)
-  public void shouldFailIfSchemaKeyFieldNotPresentInSchema() throws Exception {
-    config.put(DatagenConnectorConfig.QUICKSTART_CONF, DatagenTask.Quickstart.USERS.name());
-    config.put(DatagenConnectorConfig.SCHEMA_KEYFIELD_CONF, "key_does_not_exist");
-    createTask();
-    generateRecords();
-  }
-
   private void generateAndValidateRecordsFor(DatagenTask.Quickstart quickstart) throws Exception {
     createTaskWith(quickstart);
     generateRecords();

--- a/src/test/resources/invalid_users_schema.avro
+++ b/src/test/resources/invalid_users_schema.avro
@@ -1,0 +1,37 @@
+{
+        "namespace": "ksql",
+        "name": "users",
+        "type": "record",
+        "fields": [
+                {"name": "registertime", "type": {
+                    "type": "long",
+                    "arg.properties": {
+                        "range": {
+                            "min": 1487715775521,
+                            "max": 1519273364600
+                        }
+                    }
+                }},
+                {"name": "userid", "type": {
+                    "type": "string",
+                    "arg.properties": {
+                        "regex": "User_[1-9]{0,1}"
+                    }
+                }},
+                {"name": "regionid", "type": {
+                    "type": "string",
+                    "arg.properties": {
+                        "regex": "Region_[1-9]?"
+                    }
+                }},
+                {"name": "gender", "type": {
+                    "type": "string",
+                    "arg.properties": {
+                        "options": [
+                            "MALE",
+                            "FEMALE",
+                            "OTHER"
+                        ]
+                    }
+                }}
+        ]


### PR DESCRIPTION
## Problem
The connector fails immediately after starting if provided schema (via any of the three schema sources) or schema key field is invalid.

## Solution
Add schema validations, so that the connector doesn't start with an invalid schema or schema key field.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy
Added unit tests

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Open Questions
- Should this go to a new minor version branch (0.5.x) as this isn't a bugfix and according to semver patch version bumps should only be for bug fixes
