### PR TITLE
CCLOG-402: Remove redundant quantifiers from quickstart schema template

### DIFF
--- a/src/main/resources/pageviews_schema.avro
+++ b/src/main/resources/pageviews_schema.avro
@@ -13,13 +13,13 @@
                 {"name": "userid", "type": {
                     "type": "string",
                     "arg.properties": {
-                        "regex": "User_[1-9]{0,1}"
+                        "regex": "User_[1-9]"
                     }
                 }},
                 {"name": "pageid", "type": {
                     "type": "string",
                     "arg.properties": {
-                        "regex": "Page_[1-9][0-9]?"
+                        "regex": "Page_[1-9][0-9]"
                     }
                 }}
         ]

--- a/src/main/resources/stock_trades_schema.avro
+++ b/src/main/resources/stock_trades_schema.avro
@@ -66,7 +66,7 @@
       "type": {
         "type": "string",
         "arg.properties": {
-            "regex": "User_[1-9]{0,1}"
+            "regex": "User_[1-9]"
         }
       }
     }

--- a/src/main/resources/users_array_map_schema.avro
+++ b/src/main/resources/users_array_map_schema.avro
@@ -15,13 +15,13 @@
                 {"name": "userid", "type": {
                     "type": "string",
                     "arg.properties": {
-                        "regex": "User_[1-9]{0,1}"
+                        "regex": "User_[1-9]"
                     }
                 }},
                 {"name": "regionid", "type": {
                     "type": "string",
                     "arg.properties": {
-                        "regex": "Region_[1-9]?"
+                        "regex": "Region_[1-9]"
                     }
                 }},
                 {"name": "gender", "type": {

--- a/src/main/resources/users_schema.avro
+++ b/src/main/resources/users_schema.avro
@@ -15,13 +15,13 @@
                 {"name": "userid", "type": {
                     "type": "string",
                     "arg.properties": {
-                        "regex": "User_[1-9]{0,1}"
+                        "regex": "User_[1-9]"
                     }
                 }},
                 {"name": "regionid", "type": {
                     "type": "string",
                     "arg.properties": {
-                        "regex": "Region_[1-9]?"
+                        "regex": "Region_[1-9]"
                     }
                 }},
                 {"name": "gender", "type": {


### PR DESCRIPTION
## Problem
* https://confluentinc.atlassian.net/browse/CCLOG-402

{0,1} and ? are java quantifiers which allow user to specify the number of occurrences to match against. Below are some commonly used quantifiers in Java. 

```
X*        Zero or more occurrences of X
X?        Zero or One occurrences of X
X+        One or More occurrences of X
X{n}      Exactly n occurrences of X 
X{n, }    At-least n occurrences of X
X{n, m}   Count of occurrences of X is from n to m
```
So basically regex X{0,1} and X? implies same thing, i.e, the character X should occur once or not at all. For datagen connector, this quantifier is redundant as the character X is occurring always once. So removal of these quantifiers should not effect the functionality of connector - it would produce same records as earlier 

## Solution
Remove redundant quantifiers from the schema files. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
