### PR TITLE
CCLOG-1086  Cve fixes for CVE-2021-28168-1, CVE-2021-35515, CVE-2021-36090, CVE-2…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>6.0.0</version>
+        <version>6.0.3</version>
     </parent>
 
     <groupId>io.confluent.kafka.connect</groupId>
@@ -30,10 +30,11 @@
 
 
     <properties>
+        <commons.compress.version>1.21</commons.compress.version>
         <connect-runtime-version>2.0.0</connect-runtime-version>
         <confluent.avro.generator.version>0.4.0</confluent.avro.generator.version>
         <junit.version>4.12</junit.version>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>30.0-jre</guava.version>
         <avro.version>1.8.1</avro.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
@@ -137,6 +138,12 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <scope>test</scope>
+        </dependency>
+        <!-- pinning for CVEs -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${commons.compress.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
…021-35516, CVE-2021-35517, CVE-2020-25649, CVE-2020-8908 in datagen source connector

## Problem
CVEs in datagen source connector 

- CVE-2021-28168-1
- CVE-2021-35515
- CVE-2021-36090
- CVE-2021-35516
- CVE-2021-35517
- CVE-2020-25649
- CVE-2020-8908

## Solution
Upgraded version of `common-parent` dependency. 
Pinned the version of `org.apache.commons:commons-compress` for cve fix. 
Upgraded guava dependency version. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Build passes locally.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
