### PR TITLE
MINOR: Bump Avro Random Generator dependency to fix regex string generation bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <properties>
         <commons.compress.version>1.21</commons.compress.version>
         <connect-runtime-version>2.0.0</connect-runtime-version>
-        <confluent.avro.generator.version>0.4.0</confluent.avro.generator.version>
+        <confluent.avro.generator.version>0.4.1</confluent.avro.generator.version>
         <junit.version>4.12</junit.version>
         <guava.version>30.0-jre</guava.version>
         <avro.version>1.8.1</avro.version>


### PR DESCRIPTION
Pulls in the fix from https://github.com/confluentinc/avro-random-generator/pull/22, which is included in the recent [0.4.1 release](https://github.com/confluentinc/avro-random-generator/commits/v0.4.1).
