### PR TITLE
Adding timeout support for generator.generate() 

### DIFF
--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
@@ -298,8 +298,8 @@ public class DatagenTask extends SourceTask {
       case ARRAY:
         final List<?> list = (List<?>) value;
         return list.stream()
-                   .map(listItem -> getOptionalValue(schema.valueSchema(), listItem))
-                   .collect(Collectors.toList());
+          .map(listItem -> getOptionalValue(schema.valueSchema(), listItem))
+          .collect(Collectors.toList());
       case MAP:
         final Map<?, ?> map = (Map<?, ?>) value;
         return map.entrySet().stream()


### PR DESCRIPTION
## Problem
Avro random library 'generator.generate()' is a blocking call in task `poll()` method of datagen source connector. Practically, it is possible to create a regex which can make this method run indefinitely.
## Solution
 Idea is to add a timeout for the same post which the task will fail with an exception. Timeout would be a parameter which can be configured. On cloud, this can be a specific value which can be decided after performance testing.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
NA

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
