### PR TITLE
CCLOG-1921 Fix for CVE-2020-36518

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>6.0.7</version>
+        <version>7.2.0</version>
     </parent>
 
     <groupId>io.confluent.kafka.connect</groupId>
@@ -94,7 +94,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-data</artifactId>
-            <version>${confluent.version}</version>
+            <version>${confluent.version.range}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>
@@ -105,11 +105,6 @@
                     <artifactId>zkclient</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -125,7 +120,7 @@
         <!-- Inherited unnecessarily, scope to test so it's not packaged -->
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -74,14 +74,14 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 
     <pluginRepositories>
         <pluginRepository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </pluginRepository>
     </pluginRepositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,11 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Use a repackaged version of log4j with security patches. Default log4j v1.2 is a transitive dependency of slf4j-log4j12, but it is excluded in common/pom.xml -->
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>confluent-log4j</artifactId>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common-parent</artifactId>
-        <version>5.5.0</version>
+        <version>6.0.7</version>
     </parent>
 
     <groupId>io.confluent.kafka.connect</groupId>

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnector.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnector.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.kafka.connect.datagen;
 

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnectorConfig.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenConnectorConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.kafka.connect.datagen;
 

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.kafka.connect.datagen;
 

--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
@@ -68,7 +68,7 @@ public class DatagenTask extends SourceTask {
   private int taskId;
   private Map<String, Object> sourcePartition;
   private long taskGeneration;
-  private Random random;
+  private final Random random = new Random();
 
   protected enum Quickstart {
     CLICKSTREAM_CODES("clickstream_codes_schema.avro", "code"),
@@ -117,7 +117,6 @@ public class DatagenTask extends SourceTask {
     taskId = Integer.parseInt(props.get(TASK_ID));
     sourcePartition = Collections.singletonMap(TASK_ID, taskId);
 
-    random = new Random();
     if (config.getRandomSeed() != null) {
       random.setSeed(config.getRandomSeed());
       // Each task will now deterministically advance it's random source

--- a/src/main/java/io/confluent/kafka/connect/datagen/VersionUtil.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/VersionUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright 2018 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- **/
+ */
 
 package io.confluent.kafka.connect.datagen;
 


### PR DESCRIPTION
## Problem
https://nvd.nist.gov/vuln/detail/CVE-2020-36518

## Solution
Upgraded the common version, to bring in the version of jackson-databind which has the fix for this cve.
Also had to import `confluent-log4j` to avoid the following error in tests, where log4j dependency wasn't being pulled in. 
```
[ERROR] Tests run: 14, Failures: 0, Errors: 14, Skipped: 0, Time elapsed: 0.01 s <<< FAILURE! - in io.confluent.kafka.connect.datagen.DatagenTaskTest
[ERROR] io.confluent.kafka.connect.datagen.DatagenTaskTest.shouldGenerateFilesForUsersQuickstart  Time elapsed: 0.001 s  <<< ERROR!
java.lang.NoClassDefFoundError: org/apache/log4j/Level
        at io.confluent.kafka.connect.datagen.DatagenTaskTest.<clinit>(DatagenTaskTest.java:58)
Caused by: java.lang.ClassNotFoundException: org.apache.log4j.Level
        at io.confluent.kafka.connect.datagen.DatagenTaskTest.<clinit>(DatagenTaskTest.java:58)
```

Also found spotbugs validate check failure listed below 
```
[INFO] --- spotbugs-maven-plugin:4.5.3.0:check (default) @ kafka-connect-datagen ---
[INFO] BugInstance size is 2
[INFO] Error size is 0
[INFO] Total bugs: 2
[ERROR] High: Random object created and used only once in io.confluent.kafka.connect.datagen.DatagenTask.start(Map) [io.confluent.kafka.connect.datagen.DatagenTask] At DatagenTask.java:[line 127] DMI_RANDOM_USED_ONLY_ONCE
[ERROR] High: Random object created and used only once in io.confluent.kafka.connect.datagen.DatagenTask.start(Map) [io.confluent.kafka.connect.datagen.DatagenTask, io.confluent.kafka.connect.datagen.DatagenTask, io.confluent.kafka.connec
t.datagen.DatagenTask] At DatagenTask.java:[line 123]Another occurrence at DatagenTask.java:[line 127]Another occurrence at DatagenTask.java:[line 136] DMI_RANDOM_USED_ONLY_ONCE
```

Addressed by making `random` instance variable a constant (final) per task instance. Verified that using same seed in user configs, two connector instances generate same stream of data. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes 
- [ ] no

##### If yes, where?
applies to other connectors as well. Also in all the branches of datagen.

## Test Strategy
All existing unit tests succeed. 
Manually verified the jackson-databind dependency being pulled in.
```
*[cclog-1921][~/workspace/kafka-connect-datagen]$ mvn dependency:tree | grep 'jackson-databind'                                                                                                                                    cclog-1921
[INFO] |  |  +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.2.2:compile
```

Also, deployed the snapshot version of connector with these (this pr's) changes locally and verified that two instances of the connector with same seed generate same data stream with USERS quickstart. 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
