### PR TITLE
RCCA-8574: Handle default value as null for complex data types

### DIFF
--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
@@ -81,7 +81,8 @@ public class DatagenTask extends SourceTask {
     PAGEVIEWS("pageviews_schema.avro", "viewtime"),
     STOCK_TRADES("stock_trades_schema.avro", "symbol"),
     INVENTORY("inventory.avro", "id"),
-    PRODUCT("product.avro", "id");
+    PRODUCT("product.avro", "id"),
+    PERSON("person_schema.avro", "person");
 
     private final String schemaFilename;
     private final String keyName;
@@ -306,6 +307,10 @@ public class DatagenTask extends SourceTask {
       final org.apache.kafka.connect.data.Schema schema,
       final Object value
   ) {
+    if (value == null) {
+      return null;
+    }
+
     switch (schema.type()) {
       case BOOLEAN:
       case INT32:

--- a/src/main/resources/person_schema.avro
+++ b/src/main/resources/person_schema.avro
@@ -1,0 +1,62 @@
+{
+  "connect.name": "simple.avro.SimplePersonAvro",
+  "fields": [
+    {
+      "name": "person",
+      "type": {
+        "items": {
+          "connect.name": "simple.avro.Person",
+          "fields": [
+            {
+              "default": null,
+              "name": "name",
+              "type": [
+                "null",
+                "string"
+              ]
+            },
+            {
+              "default": null,
+              "name": "age",
+              "type": [
+                "null",
+                "string"
+              ]
+            }
+          ],
+          "name": "Person",
+          "type": "record"
+        },
+        "type": "array"
+      }
+    },
+    {
+      "default": null,
+      "name": "father",
+      "type": [
+        "null",
+        {
+          "connect.name": "simple.avro.Parent",
+          "fields": [
+            {
+              "default": null,
+              "name": "greatGrandParents",
+              "type": [
+                "null",
+                {
+                  "items": "Person",
+                  "type": "array"
+                }
+              ]
+            }
+          ],
+          "name": "Parent",
+          "type": "record"
+        }
+      ]
+    }
+  ],
+  "name": "SimplePersonAvro",
+  "namespace": "simple.avro",
+  "type": "record"
+}

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
@@ -93,6 +93,11 @@ public class DatagenTaskTest {
   }
 
   @Test
+  public void shouldGenerateFilesForPersonQuickstart() throws Exception {
+    generateAndValidateRecordsFor(DatagenTask.Quickstart.PERSON);
+  }
+
+  @Test
   public void shouldGenerateFilesForOrdersQuickstart() throws Exception {
     generateAndValidateRecordsFor(DatagenTask.Quickstart.ORDERS);
   }


### PR DESCRIPTION
## Problem
Complex schema type such as array, struct, maps having default value as null is causing a NPE

## Solution
When a complex schema type is received, we further expand it to get to native data types by typecasting the value.
Before typecasting the value, we should check for the null value and return if a null value is found


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
