### PR TITLE
RCCA-8574: Handle default value as null for complex data types

### DIFF
--- a/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/DatagenTask.java
@@ -288,6 +288,10 @@ public class DatagenTask extends SourceTask {
       final org.apache.kafka.connect.data.Schema schema,
       final Object value
   ) {
+    if (value == null) {
+      return null;
+    }
+
     switch (schema.type()) {
       case BOOLEAN:
       case INT32:

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenTaskTest.java
@@ -97,6 +97,70 @@ public class DatagenTaskTest {
   }
 
   @Test
+  public void shouldGenerateFilesForPersonQuickstart() throws Exception {
+    String personSchema = "{\n" +
+            "  \"name\": \"SimplePersonAvro\",\n" +
+            "  \"type\": \"record\",\n" +
+            "  \"namespace\": \"simple.avro\",\n" +
+            "  \"fields\": [\n" +
+            "    {\n" +
+            "      \"name\": \"person\",\n" +
+            "      \"type\": {\n" +
+            "        \"type\": \"array\",\n" +
+            "        \"items\": {\n" +
+            "          \"name\": \"Person\",\n" +
+            "          \"type\": \"record\",\n" +
+            "          \"fields\": [\n" +
+            "            {\n" +
+            "              \"name\": \"name\",\n" +
+            "              \"type\": [\n" +
+            "                \"null\",\n" +
+            "                \"string\"\n" +
+            "              ],\n" +
+            "              \"default\": null\n" +
+            "            },\n" +
+            "            {\n" +
+            "              \"name\": \"age\",\n" +
+            "              \"type\": [\n" +
+            "                \"null\",\n" +
+            "                \"string\"\n" +
+            "              ],\n" +
+            "              \"default\": null\n" +
+            "            }\n" +
+            "          ]\n" +
+            "        }\n" +
+            "      }\n" +
+            "    },\n" +
+            "    {\n" +
+            "      \"name\": \"father\",\n" +
+            "      \"default\": null,\n" +
+            "      \"type\": [\n" +
+            "        \"null\",\n" +
+            "        {\n" +
+            "          \"name\": \"Parent\",\n" +
+            "          \"type\": \"record\",\n" +
+            "          \"fields\": [\n" +
+            "            {\n" +
+            "              \"name\": \"greatGrandParents\",\n" +
+            "              \"default\": null,\n" +
+            "              \"type\": [\n" +
+            "                \"null\",\n" +
+            "                {\n" +
+            "                  \"type\": \"array\",\n" +
+            "                  \"items\": \"simple.avro.Person\"\n" +
+            "                }\n" +
+            "              ]\n" +
+            "            }\n" +
+            "          ]\n" +
+            "        }\n" +
+            "      ]\n" +
+            "    }\n" +
+            "  ]\n" +
+            "}";
+    generateAndValidateRecordsForSchemaString(personSchema, "person");
+  }
+
+  @Test
   public void shouldGenerateFilesForOrdersQuickstart() throws Exception {
     generateAndValidateRecordsFor(DatagenTask.Quickstart.ORDERS);
   }
@@ -239,6 +303,12 @@ public class DatagenTaskTest {
 
     // Do the same thing with schema text
     createTaskWithSchemaText(slurp(quickstart.getSchemaFilename()), quickstart.getSchemaKeyField());
+    generateRecords();
+    assertRecordsMatchSchemas();
+  }
+
+  private void generateAndValidateRecordsForSchemaString(String schemaString, String keyField) throws Exception {
+    createTaskWithSchemaText(schemaString, keyField);
     generateRecords();
     assertRecordsMatchSchemas();
   }


### PR DESCRIPTION
## Problem
Complex schema type such as array, struct, maps having default value as null is causing a NPE

## Solution

When a complex schema type is received, we further expand it to get to native data types by typecasting the value.
Before typecasting the value, we should check for the null value and return if a null value is found

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
