### PR TITLE
CC-21503 Increase guava version to 32.0.1-jre to address CVE-2023-2976

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <connect-runtime-version>2.0.0</connect-runtime-version>
         <confluent.avro.generator.version>0.3.1</confluent.avro.generator.version>
         <junit.version>4.12</junit.version>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>32.0.1-jre</guava.version>
         <avro.version>1.8.1</avro.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
     </properties>


### PR DESCRIPTION
## Problem
https://nvd.nist.gov/vuln/detail/CVE-2023-2976

## Solution
Increasing guava dependency version to recommended 32.0.1-jre.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
All existing unit tests run fine. 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
