### PR TITLE
Update shoe_orders.avro timestamp

### DIFF
--- a/src/main/resources/shoe_orders.avro
+++ b/src/main/resources/shoe_orders.avro
@@ -986,7 +986,7 @@
                 "logicalType": "timestamp-millis",
                 "arg.properties": {
                     "iteration": {
-                        "start": 1609459200000,
+                        "start": 1672531200000,
                         "step": 100000
                     }
                 }


### PR DESCRIPTION
Moving the timestamp to 1.1.2023

## Problem

Timestamp generated in the message is from 2021

## Solution

Change timestamp to be starting in 2023

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
