### PR TITLE
CC-24021: Enable pint merge

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,4 +5,5 @@
 common {
   slackChannel = '#connect-warn'
   nodeLabel = 'docker-debian-jdk8'
+  pintMerge = true
 }


### PR DESCRIPTION
jenkins job is failing because of pint merge. Fixing pint merge: https://jenkins.confluent.io/job/confluentinc/job/kafka-connect-datagen/job/master/