### PR TITLE
CC-25375: CVE fix for apache common-compress package

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
 
     <properties>
-        <commons.compress.version>1.21</commons.compress.version>
+        <commons.compress.version>1.26</commons.compress.version>
         <connect-runtime-version>2.0.0</connect-runtime-version>
         <confluent.avro.generator.version>0.4.1</confluent.avro.generator.version>
         <junit.version>4.12</junit.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 
 
     <properties>
-        <commons.compress.version>1.26</commons.compress.version>
+        <commons.compress.version>1.26.0</commons.compress.version>
         <connect-runtime-version>2.0.0</connect-runtime-version>
         <confluent.avro.generator.version>0.4.1</confluent.avro.generator.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
## Problem

```
[CVE-2024-25710](https://nvd.nist.gov/vuln/detail/CVE-2024-25710) : Loop with Unreachable Exit Condition ('Infinite Loop') vulnerability in Apache Commons Compress.This issue affects Apache Commons Compress: from 1.3 through 1.25.0. Users are recommended to upgrade to version 1.26.0 which fixes the issue.
```

## Solution

Upgrade package commons.compress to 1.26.0

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
