### PR TITLE
Fix schema parsing issue

### DIFF
--- a/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
@@ -20,9 +20,9 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Parser;
-import org.apache.avro.SchemaParseException;
 import org.apache.kafka.common.config.ConfigException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,10 +35,10 @@ public class ConfigUtils {
     Schema schema;
     try {
       schema = schemaParser.parse(schemaString);
-    } catch (SchemaParseException | AvroRuntimeException e) {
+    } catch (AvroRuntimeException e) {
       log.error("Unable to parse the provided schema", e);
       throw new ConfigException("Unable to parse the provided schema");
-
+    }
     return schema;
   }
 
@@ -56,11 +56,11 @@ public class ConfigUtils {
         schema = schemaParser.parse(
           DatagenTask.class.getClassLoader().getResourceAsStream(schemaFileName)
         );
-      } catch (SchemaParseException | AvroRuntimeException | IOException i) {
+      } catch (AvroRuntimeException | IOException i) {
         log.error("Unable to parse the provided schema", i);
         throw new ConfigException("Unable to parse the provided schema");
       }
-    } catch (SchemaParseException | AvroRuntimeException | IOException e) {
+    } catch (AvroRuntimeException | IOException e) {
       log.error("Unable to parse the provided schema", e);
       throw new ConfigException("Unable to parse the provided schema");
     }

--- a/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
@@ -35,10 +35,10 @@ public class ConfigUtils {
     Schema schema;
     try {
       schema = schemaParser.parse(schemaString);
-    } catch (SchemaParseException e) {
+    } catch (SchemaParseException | AvroRuntimeException e) {
       log.error("Unable to parse the provided schema", e);
       throw new ConfigException("Unable to parse the provided schema");
-    }
+
     return schema;
   }
 
@@ -56,11 +56,11 @@ public class ConfigUtils {
         schema = schemaParser.parse(
           DatagenTask.class.getClassLoader().getResourceAsStream(schemaFileName)
         );
-      } catch (SchemaParseException | IOException i) {
+      } catch (SchemaParseException | AvroRuntimeException | IOException i) {
         log.error("Unable to parse the provided schema", i);
         throw new ConfigException("Unable to parse the provided schema");
       }
-    } catch (SchemaParseException | IOException e) {
+    } catch (SchemaParseException | AvroRuntimeException | IOException e) {
       log.error("Unable to parse the provided schema", e);
       throw new ConfigException("Unable to parse the provided schema");
     }


### PR DESCRIPTION
## Problem

Currently validation request throws 500 if schema.string value have two fields with same name.

## Solution

SchemaParseException only cover  specific error related to schema parsing but there is super class AvroRuntimeException which covers more broder issue while parsing schema. For example, Duplicate keys in schema. 

https://github.com/apache/avro/blob/release-1.11.4/lang/java/avro/src/main/java/org/apache/avro/SchemaParseException.java#L22

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

Tested with below curl

```
curl 'http://localhost:9021/api/connect/connect-default/connector-plugins/io.confluent.kafka.connect.datagen.DatagenConnector/config/validate' \
  -X 'PUT' \
  -H 'Accept: */*' \
  -H 'Accept-Language: en-US,en;q=0.9' \
  -H 'Connection: keep-alive' \
  -H 'Content-Type: application/json' \
  -H 'Origin: http://localhost:9021' \
  -H 'Referer: http://localhost:9021/clusters/szjGjm_-S_moNBWZRb9bvw/management/connect/connect-default/connectors/new-source/io.confluent.kafka.connect.datagen.DatagenConnector' \
  -H 'Sec-Fetch-Dest: empty' \
  -H 'Sec-Fetch-Mode: cors' \
  -H 'Sec-Fetch-Site: same-origin' \
  -H 'User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36' \
  -H 'X-Requested-By: cece19c1-7ddf-47b6-8d4c-9c047be28df0' \
  -H 'X-Requested-With: undefined' \
  -H 'sec-ch-ua: "Chromium";v="134", "Not:A-Brand";v="24", "Google Chrome";v="134"' \
  -H 'sec-ch-ua-mobile: ?0' \
  -H 'sec-ch-ua-platform: "macOS"' \
  --data-raw '{"name":"DatagenConnectorConnector_1","connector.class":"io.confluent.kafka.connect.datagen.DatagenConnector","tasks.max":"1","tasks.max.enforce":"true","key.converter":"org.apache.kafka.connect.storage.StringConverter","value.converter":"org.apache.kafka.connect.json.JsonConverter","kafka.topic":"topic_2","iterations":"1000","schema.string":"{ \"type\": \"record\", \"name\": \"User\", \"fields\": [ { \"name\": \"username\", \"type\": \"string\" }, { \"name\": \"username\", \"type\": \"string\" } ] }","value.converter.schemas.enable":"true"}'
  
  ```
  <img width="562" alt="Screenshot 2025-04-03 at 1 10 39 PM" src="https://github.com/user-attachments/assets/0ff94104-95be-413e-8836-86626b7b267a" />
<img width="1281" alt="Screenshot 2025-04-03 at 1 15 02 PM" src="https://github.com/user-attachments/assets/ead58275-5c28-4ba2-939c-2e399acb079b" />
  

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
