### PR TITLE
[CC-40424] Marked SR related dependencies as provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,17 @@
                     <groupId>com.101tec</groupId>
                     <artifactId>zkclient</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>io.confluent</groupId>
+                    <artifactId>kafka-avro-serializer</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-avro-serializer</artifactId>
+            <version>${confluent.version.range}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
## Summary
The `kafka-connect-avro-data` dependency transitively pulls in `kafka-avro-serializer` (and its own transitive SR deps like `kafka-schema-serializer`, `kafka-schema-registry-client`) at compile scope. However, this project only uses AvroData and core Avro classes — none of the serializer or Schema Registry client classes are imported or referenced anywhere in the codebase.

This PR excludes `kafka-avro-serializer` from `kafka-connect-avro-data` and re-declares it as provided, so it (and its transitives) are available at compile time but not packaged into the connector artifact.

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## KDP
Command - `playground run -f ./datagen-source.sh --connector-jar /Users/armangarg/confluentinc/kafka-connect-datagen/target/kafka-connect-datagen-0.7.2-SNAPSHOT.jar`

```
10:09:59 ℹ️ 🎱 Installing connector confluentinc/kafka-connect-datagen:latest
10:10:02 ℹ️ 🔮 Remplacing kafka-connect-datagen-0.7.1.jar by kafka-connect-datagen-0.7.2-SNAPSHOT.jar

10:11:13 ℹ️ 🧩 Displaying status for 🌎onprem connector datagen-customers
Name                           Status       Tasks                                                        Stack Trace
-------------------------------------------------------------------------------------------------------------
datagen-customers              ✅ RUNNING  0:🛑 FAILED[connect],1:🛑 FAILED[connect],2:🛑 FAILED[connect],3:🛑 FAILED[connect],4:🛑 FAILED[connect],5:🛑 FAILED[connect],6:🛑 FAILED[connect],7:🛑 FAILED[connect],8:🛑 FAILED[connect],9:🛑 FAILED[connect]  tasks: org.apache.kafka.connect.errors.ConnectException: Stopping connector: generated the configured 1000 number of messages

10:11:39 ℹ️ ####################################################
10:11:39 ℹ️ ✅ RESULT: SUCCESS for datagen-source.sh (took: 1min 40sec - )
10:11:39 ℹ️ ####################################################

10:11:43 ℹ️ ✨ --connector flag was not provided, applying command to all connectors
```
