### PR TITLE
[Fix] LinkageError: loader constraint violation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-data</artifactId>
             <version>${confluent.version.range}</version>
+            <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.zookeeper</groupId>
@@ -140,15 +141,31 @@
                     <groupId>com.101tec</groupId>
                     <artifactId>zkclient</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.confluent</groupId>
-                    <artifactId>kafka-avro-serializer</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+<!--        Marking SR related dependencies as provided-->
+        <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-avro-serializer</artifactId>
+            <version>${confluent.version.range}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-serializer</artifactId>
+            <version>${confluent.version.range}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-schema-registry-client</artifactId>
             <version>${confluent.version.range}</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
## Summary

  `kafka-connect-datagen` bundled the entire Avro + Schema Registry stack in its plugin lib (`avro`, `kafka-connect-avro-data`, `kafka-schema-registry-client`,
  `kafka-avro-serializer`, `kafka-schema-serializer`). The Kafka Connect runtime already supplies these on its app classpath via `cc-docker-connect/cc-converters` (copied
  into `/opt/confluent/libs/`), so we defer the whole chain to the runtime.

  ### Changes (`pom.xml`)

  | Dependency | Before | After |
  |---|---|---|
  | `io.confluent:kafka-connect-avro-data` | compile | `provided` |
  | `org.apache.avro:avro` | (transitive, bundled) | `provided` (direct) |
  | `io.confluent:kafka-avro-serializer` | `provided` | `provided` (unchanged) |
  | `io.confluent:kafka-schema-serializer` | (transitive, bundled) | `provided` (direct) |
  | `io.confluent:kafka-schema-registry-client` | (transitive, bundled) | `provided` (direct) |

  ### Why all of these together

  `DatagenTask:104-105` constructs an `AvroData` and calls `toConnectSchema(avroSchema)`. Internally that calls `new AvroSchema(org.apache.avro.Schema, Integer)` for cache
  lookup. If `AvroData` lives in the plugin classloader (bundled) and `AvroSchema` lives on the app classloader (runtime), the JVM enforces a loader-constraint check on the
  parameter type `org.apache.avro.Schema` — and the plugin's bundled `avro-1.12.1` vs runtime's `avro-1.11.4` produce two different `Class` objects, triggering
  `LinkageError`.

  Marking only the SR jars as `provided` is insufficient: `kafka-connect-avro-data` and `avro` must also be `provided` so the entire `AvroData` ↔ `AvroSchema` ↔ `Schema`
  graph resolves through a single classloader (the app one). The SR jars are declared explicitly even though they'd cascade as transitives — direct declarations make the
  runtime contract immune to upstream packaging changes.

  ### Runtime guarantee

  All five `provided`-scoped artifacts ship via `cc-docker-connect/cc-converters` into `/opt/confluent/libs/`.

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## KDP
Command - `playground run -f ./datagen-source.sh \
    --connector-zip /Users/armangarg/confluentinc/kafka-connect-datagen/target/components/packages/confluentinc-kafka-connect-datagen-0.7.2-SNAPSHOT.zip`

```
16:44:44 ℹ️ 🎱 Installing connector from zip confluentinc-kafka-connect-datagen-0.7.2-SNAPSHOT.zip
16:46:58 ℹ️ ####################################################
16:46:58 ℹ️ ✅ RESULT: SUCCESS for datagen-source.sh (took: 2min 16sec - )
16:46:58 ℹ️ ####################################################

16:47:04 ℹ️ ✨ --connector flag was not provided, applying command to all connectors
16:47:04 ℹ️ 🧩 Displaying status for 🌎onprem connector datagen-orders
Name                           Status       Tasks                                                        Stack Trace
-------------------------------------------------------------------------------------------------------------
datagen-orders                 ✅ RUNNING  0:🛑 FAILED[connect],1:🛑 FAILED[connect],2:🛑 FAILED[connect],3:🛑 FAILED[connect],4:🛑 FAILED[connect],5:🛑 FAILED[connect],6:🛑 FAILED[connect],7:🛑 FAILED[connect],8:🛑 FAILED[connect],9:🛑 FAILED[connect]  tasks: org.apache.kafka.connect.errors.ConnectException: Stopping connector: generated the configured 10000 number of messages
```