### PR TITLE
CC-41483: Catch RuntimeException during schema parsing to avoid NPE leaking out of config validation

### DIFF
--- a/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
@@ -20,7 +20,6 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import org.apache.avro.AvroRuntimeException;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Parser;
 import org.apache.kafka.common.config.ConfigException;
@@ -35,7 +34,12 @@ public class ConfigUtils {
     Schema schema;
     try {
       schema = schemaParser.parse(schemaString);
-    } catch (AvroRuntimeException e) {
+    } catch (RuntimeException e) {
+      // Defensive catch of RuntimeException (not just AvroRuntimeException): the Avro
+      // parser can surface invalid schemas as other RuntimeExceptions (e.g. a raw
+      // NullPointerException for an unresolved named reference). Catching the broader
+      // type ensures any parse failure is reported as a ConfigException during config
+      // validation instead of leaking out and breaking the validation response.
       log.error("Unable to parse the provided schema", e);
       throw new ConfigException("Unable to parse the provided schema");
     }
@@ -56,11 +60,11 @@ public class ConfigUtils {
         schema = schemaParser.parse(
           DatagenTask.class.getClassLoader().getResourceAsStream(schemaFileName)
         );
-      } catch (AvroRuntimeException | IOException i) {
+      } catch (RuntimeException | IOException i) {
         log.error("Unable to parse the provided schema", i);
         throw new ConfigException("Unable to parse the provided schema");
       }
-    } catch (AvroRuntimeException | IOException e) {
+    } catch (RuntimeException | IOException e) {
       log.error("Unable to parse the provided schema", e);
       throw new ConfigException("Unable to parse the provided schema");
     }

--- a/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
+++ b/src/main/java/io/confluent/kafka/connect/datagen/ConfigUtils.java
@@ -35,11 +35,6 @@ public class ConfigUtils {
     try {
       schema = schemaParser.parse(schemaString);
     } catch (RuntimeException e) {
-      // Defensive catch of RuntimeException (not just AvroRuntimeException): the Avro
-      // parser can surface invalid schemas as other RuntimeExceptions (e.g. a raw
-      // NullPointerException for an unresolved named reference). Catching the broader
-      // type ensures any parse failure is reported as a ConfigException during config
-      // validation instead of leaking out and breaking the validation response.
       log.error("Unable to parse the provided schema", e);
       throw new ConfigException("Unable to parse the provided schema");
     }

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenConnectorTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenConnectorTest.java
@@ -150,11 +150,6 @@ class DatagenConnectorTest {
 
   @Test
   void shouldFailValidationWithUnresolvedSchemaReference() {
-    // A syntactically valid schema that is a bare reference to an undefined named
-    // type. The Avro parser surfaces this as a raw RuntimeException
-    // (NullPointerException: "Unknown schema: ...UnresolvedSchema_N") rather than an
-    // AvroRuntimeException; validation must still report it as a config error instead
-    // of letting it escape and break the validation response.
     clearSchemaSources();
     config.put(DatagenConnectorConfig.SCHEMA_STRING_CONF, "{\"type\":\"Address\"}");
     Config validated = connector.validate(config);

--- a/src/test/java/io/confluent/kafka/connect/datagen/DatagenConnectorTest.java
+++ b/src/test/java/io/confluent/kafka/connect/datagen/DatagenConnectorTest.java
@@ -149,6 +149,22 @@ class DatagenConnectorTest {
   }
 
   @Test
+  void shouldFailValidationWithUnresolvedSchemaReference() {
+    // A syntactically valid schema that is a bare reference to an undefined named
+    // type. The Avro parser surfaces this as a raw RuntimeException
+    // (NullPointerException: "Unknown schema: ...UnresolvedSchema_N") rather than an
+    // AvroRuntimeException; validation must still report it as a config error instead
+    // of letting it escape and break the validation response.
+    clearSchemaSources();
+    config.put(DatagenConnectorConfig.SCHEMA_STRING_CONF, "{\"type\":\"Address\"}");
+    Config validated = connector.validate(config);
+    assertThat(
+      validated,
+      hasValidationError(DatagenConnectorConfig.SCHEMA_STRING_CONF, 1)
+    );
+  }
+
+  @Test
   void shouldFailValidationWithInvalidFileName() {
     clearSchemaSources();
     config.put(DatagenConnectorConfig.SCHEMA_FILENAME_CONF, "a file name");


### PR DESCRIPTION
## Problem

During connector config validation, `SchemaStringValidator.ensureValid` / `SchemaFileValidator.ensureValid` call into `ConfigUtils` to parse the supplied Avro schema. Those parse methods only caught `AvroRuntimeException`. The Avro parser does not consistently wrap invalid-schema failures in `AvroRuntimeException` — some surface as other `RuntimeException`s (observed: a raw `NullPointerException` for an unresolved/undefined named reference in the schema).

When that happened, the exception escaped `getSchemaFromSchemaString` / `getSchemaFromSchemaFileName` and propagated out of config validation, breaking the validation response instead of being reported back as a normal config error:

```
java.lang.NullPointerException: Unknown schema: org.apache.avro.compiler.UnresolvedSchema_24
    at org.apache.avro.ParseContext.resolve(ParseContext.java:330)
    at org.apache.avro.Schema$Parser.parse(Schema.java:1542)
    at io.confluent.kafka.connect.datagen.ConfigUtils.getSchemaFromSchemaString(ConfigUtils.java:37)
    at io.confluent.kafka.connect.datagen.DatagenConnectorConfig$SchemaStringValidator.ensureValid(DatagenConnectorConfig.java:182)
    ...
```

## Fix

Widen the catch from `AvroRuntimeException` to `RuntimeException` in both `getSchemaFromSchemaString` and `getSchemaFromSchemaFileName`. This is a defensive check: we do not rely on the parser always wrapping failures in `AvroRuntimeException`, so any parse failure (whatever its concrete `RuntimeException` subtype) is reported gracefully as a `ConfigException` during config validation.

Note: `AvroRuntimeException` is a subtype of `RuntimeException`, so the broader catch fully subsumes the previous behavior with no loss of coverage. The now-redundant `AvroRuntimeException` import was removed.