### PR TITLE
Upgrade jackson-databind to 2.18.9 to fix CVEs (CC-42343)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <confluent.avro.generator.version>0.4.1</confluent.avro.generator.version>
         <junit.version>4.12</junit.version>
         <guava.version>32.0.1-jre</guava.version>
-        <jackson.version>2.18.6</jackson.version>
+        <jackson.version>2.18.9</jackson.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->


### PR DESCRIPTION
## Summary
- Bumps `jackson.version` (pinned via jackson-bom import in dependencyManagement) from `2.18.6` to `2.18.9` in `pom.xml`
- Resolves CVE-2026-54512, CVE-2026-54513, CVE-2026-54514, CVE-2026-54515 tracked in [CC-42343](https://confluentinc.atlassian.net/browse/CC-42343)
- Minimal patch-level bump within the same 2.18.x line (no breaking API changes); avoided the 3.1.4 option suggested in the ticket since Jackson 3.x renames all packages (`com.fasterxml.jackson` -> `tools.jackson`)

[CC-42343]: https://confluentinc.atlassian.net/browse/CC-42343