### PR TITLE
[Common BOM] Remove avro.version property override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,6 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
## Summary
- Removes the `avro.version` override for `org.apache.avro:avro` (a plain `<dependency>`, so only the `<version>` line needed to go — it inherits from the parent chain).
- `common` (pinned at `8.0.4-135`, this repo's exact parent version) declares `avro.version = 1.12.1` directly, so this is a no-op version change.
- Note: this `common` version predates `confluent-common-bom` adoption, so the value comes from `common`'s own property rather than the BOM, but the resolved version is unaffected either way.
- Verified locally via `mvn -N validate` and `mvn help:effective-pom` (resolves to `1.12.1`, unchanged).

## Tracking
Part of the `common` dependency-property cleanup effort: https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82

## Test plan
- [x] `mvn -N validate` passes
- [x] `mvn help:effective-pom` confirms `avro` resolves to `1.12.1` (unchanged)
- [ ] CI green